### PR TITLE
feat: forward metadata if not overwritten

### DIFF
--- a/src/__tests__/initialize.test.ts
+++ b/src/__tests__/initialize.test.ts
@@ -1,8 +1,9 @@
 import { act, renderHook } from '@testing-library/react'
+import { Form } from 'src/types'
 import useFormbit from 'src/use-formbit'
 import * as Yup from 'yup'
 
-const initialValues = { age: 12 }
+const initialValues = { age: 12, __metadata: { name: 'Jane' } }
 const yup = Yup.object({
   age: Yup.number(),
   new: Yup.boolean()
@@ -15,7 +16,7 @@ describe('initialize fn', () => {
 
     act(() => result.current.initialize(newInitialValues))
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     unmount()
   })
@@ -30,7 +31,7 @@ describe('initialize fn', () => {
 
     act(() => result.current.initialize(newInitialValues))
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     expect(result.current.isDirty).toBe(false)
 
@@ -45,7 +46,7 @@ describe('initialize fn', () => {
 
     act(() => result.current.initialize(newInitialValues))
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     expect(result.current.errors).toStrictEqual({})
 
@@ -62,9 +63,36 @@ describe('initialize fn', () => {
 
     act(() => result.current.initialize(newInitialValues))
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     expect(result.current.liveValidation('age')).toBe(undefined)
+
+    unmount()
+  })
+
+  it('Should not reset __metadata after initialize', () => {
+    const newInitialValues = { new: true }
+    const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
+
+    act(() => result.current.write('age', 'oneYear', { pathsToValidate: ['age'] }))
+
+    act(() => result.current.initialize(newInitialValues))
+
+    expect((result.current.form as Form).__metadata).toStrictEqual(initialValues.__metadata)
+
+    unmount()
+  })
+
+  it('Should override __metadata after initialize', () => {
+    const newInitialValues = { new: true, __metadata: { name: 'John' } }
+
+    const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
+
+    act(() => result.current.write('age', 'oneYear', { pathsToValidate: ['age'] }))
+
+    act(() => result.current.initialize(newInitialValues))
+
+    expect((result.current.form as Form).__metadata).toStrictEqual(newInitialValues.__metadata)
 
     unmount()
   })

--- a/src/__tests__/initialize.test.ts
+++ b/src/__tests__/initialize.test.ts
@@ -3,7 +3,6 @@ import { Form } from 'src/types'
 import useFormbit from 'src/use-formbit'
 import * as Yup from 'yup'
 
-const initialValues = { age: 12, __metadata: { name: 'Jane' } }
 const yup = Yup.object({
   age: Yup.number(),
   new: Yup.boolean()
@@ -11,7 +10,9 @@ const yup = Yup.object({
 
 describe('initialize fn', () => {
   it('Should initialize the form with the given initial values', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true }
+
     const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
     act(() => result.current.initialize(newInitialValues))
@@ -22,7 +23,9 @@ describe('initialize fn', () => {
   })
 
   it('Should reset isDirty after initialize', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true }
+
     const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
     act(() => result.current.write('age', 1))
@@ -39,7 +42,9 @@ describe('initialize fn', () => {
   })
 
   it('Should reset errors after initialize', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true }
+
     const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
     act(() => result.current.setError('error', 'error'))
@@ -54,7 +59,9 @@ describe('initialize fn', () => {
   })
 
   it('Should reset liveValidation after initialize', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true }
+
     const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
     act(() => result.current.write('age', 'oneYear', { pathsToValidate: ['age'] }))
@@ -71,10 +78,10 @@ describe('initialize fn', () => {
   })
 
   it('Should not reset __metadata after initialize', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true }
-    const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
-    act(() => result.current.write('age', 'oneYear', { pathsToValidate: ['age'] }))
+    const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
 
     act(() => result.current.initialize(newInitialValues))
 
@@ -84,11 +91,10 @@ describe('initialize fn', () => {
   })
 
   it('Should override __metadata after initialize', () => {
+    const initialValues = { age: 12, __metadata: { name: 'Jane' } }
     const newInitialValues = { new: true, __metadata: { name: 'John' } }
 
     const { result, unmount } = renderHook(() => useFormbit({ initialValues, yup }))
-
-    act(() => result.current.write('age', 'oneYear', { pathsToValidate: ['age'] }))
 
     act(() => result.current.initialize(newInitialValues))
 

--- a/src/__tests__/use-formbit-context.test.tsx
+++ b/src/__tests__/use-formbit-context.test.tsx
@@ -49,11 +49,11 @@ describe('useFormbitContext', () => {
 
     act(() => result.current.initialize(newInitialValues))
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     act(() => result.current.resetForm()) // resetting to check if also initialValues was overwritten
 
-    expect(result.current.form).toStrictEqual(newInitialValues)
+    expect(result.current.form).toMatchObject(newInitialValues)
 
     unmount()
   })

--- a/src/use-formbit.ts
+++ b/src/use-formbit.ts
@@ -1,5 +1,7 @@
 import objLeaves from './helpers/obj-leaves'
-import { useCallback, useRef, useState } from 'react'
+import {
+  useCallback, useRef, useState
+} from 'react'
 import { ACTIONS } from './helpers/constants'
 import {
   Check,
@@ -30,9 +32,9 @@ import useExecuteCallbacks from './use-execute-callbacks'
 import { cloneDeep, get, isEmpty, omit, set } from 'lodash'
 
 type UseFormbitParams<Values extends InitialValues> = {
-  initialValues?: Partial<Values>;
-  yup: ValidationSchema<Values>;
-};
+  initialValues?: Partial<Values>,
+  yup: ValidationSchema<Values>
+}
 
 export default <Values extends InitialValues>({
   initialValues = {},
@@ -79,9 +81,7 @@ export default <Values extends InitialValues>({
     })
   }, [])
 
-  const setSchema = useCallback((newSchema: ValidationSchema<Values>) => {
-    schemaRef.current = newSchema
-  }, [])
+  const setSchema = useCallback((newSchema: ValidationSchema<Values>) => { schemaRef.current = newSchema }, [])
 
   const setError: SetError = useCallback((path, value) => {
     setWriter((w) => {
@@ -93,344 +93,303 @@ export default <Values extends InitialValues>({
 
   const executeCb = useExecuteCallbacks<Partial<Values>>(writer, setError)
 
-  const writeOrRemove: WriteOrRemove<Values> = useCallback(
-    (
-      path,
-      value,
-      {
-        noLiveValidation = false,
-        pathsToValidate = [],
-        successCallback,
-        errorCallback,
-        options = {}
-      } = {},
-      action
-    ) => {
-      setWriter((w) => {
-        const liveValidationPaths = noLiveValidation
-          ? []
-          : Object.keys(w.liveValidation)
-        const paths = pathsToValidate.concat(liveValidationPaths)
+  const writeOrRemove: WriteOrRemove<Values> = useCallback((
+    path,
+    value,
+    {
+      noLiveValidation = false,
+      pathsToValidate = [],
+      successCallback,
+      errorCallback,
+      options = {}
+    } = {},
+    action
+  ) => {
+    setWriter((w) => {
+      const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
+      const paths = pathsToValidate.concat(liveValidationPaths)
 
-        const form = (function execute() {
-          switch (action) {
-            case ACTIONS.write:
-              return set(cloneDeep(w.form), path, value)
+      const form = (function execute() {
+        switch (action) {
+          case ACTIONS.write: return set(cloneDeep(w.form), path, value)
 
-            case ACTIONS.remove:
-              return omit<Partial<Values>>(cloneDeep(w.form), path)
+          case ACTIONS.remove: return omit<Partial<Values>>(cloneDeep(w.form), path)
 
-            default:
-              return cloneDeep(w.form)
-          }
-        })()
-
-        const newWriter: Writer<Partial<Values>> = {
-          ...w,
-          form,
-          isDirty: true
+          default: return cloneDeep(w.form)
         }
+      }())
 
-        if (paths.length === 0) {
-          executeCb(successCallback)
+      const newWriter: Writer<Partial<Values>> = { ...w, form, isDirty: true }
 
-          return newWriter
-        }
+      if (paths.length === 0) {
+        executeCb(successCallback)
 
-        // Teardown errors
-        const cleanErrors = paths.reduce(
-          (acc, key) => set(acc, key, undefined),
-          cloneDeep(newWriter.errors)
-        )
-
-        // VALIDATE
-        const inner = validateSyncAll(
-          paths,
-          schemaRef.current,
-          newWriter.form,
-          options
-        )
-
-        if (isEmpty(inner)) {
-          const neww = { ...newWriter, errors: cleanErrors }
-
-          executeCb(successCallback)
-
-          return neww
-        }
-
-        const errors = inner.reduce(
-          (acc, { path: innerPath, message }) =>
-            innerPath ? set(acc, innerPath, message) : acc,
-          cleanErrors
-        )
-
-        const liveValidation: LiveValidation = inner.reduce(
-          (acc, { path: innerPath }) =>
-            innerPath ? { ...acc, [innerPath]: true } : acc,
-          newWriter.liveValidation
-        )
-
-        const neww = { ...newWriter, errors, liveValidation }
-
-        executeCb(errorCallback)
-
-        return neww
-      })
-    },
-    [executeCb]
-  )
-
-  const write: Write<Values> = useCallback(
-    (path, value, options) =>
-      writeOrRemove(path, value, options, ACTIONS.write),
-    [writeOrRemove]
-  )
-
-  const remove: Remove<Values> = useCallback(
-    (path, options) => writeOrRemove(path, undefined, options, ACTIONS.remove),
-    [writeOrRemove]
-  )
-
-  const writeAll: WriteAll<Values> = useCallback(
-    (
-      arr,
-      {
-        noLiveValidation = false,
-        pathsToValidate = [],
-        successCallback,
-        errorCallback,
-        options = {}
-      } = {}
-    ) => {
-      setWriter((w) => {
-        const liveValidationPaths = noLiveValidation
-          ? []
-          : Object.keys(w.liveValidation)
-        const paths = pathsToValidate.concat(liveValidationPaths)
-
-        const form = arr.reduce(
-          (acc, [key, val]) => set(acc, key, val),
-          cloneDeep(w.form)
-        )
-
-        const newWriter = { ...w, form, isDirty: true }
-
-        if (paths.length === 0) {
-          executeCb(successCallback)
-
-          return newWriter
-        }
-
-        // Teardown errors
-        const cleanErrors = paths.reduce(
-          (acc, key) => set(acc, key, undefined),
-          cloneDeep(newWriter.errors)
-        )
-
-        // VALIDATE ALL
-        const inner = validateSyncAll(
-          paths,
-          schemaRef.current,
-          newWriter.form,
-          options
-        )
-
-        if (isEmpty(inner)) {
-          const neww = { ...newWriter, errors: cleanErrors }
-
-          executeCb(successCallback)
-
-          return neww
-        }
-
-        const errors = inner.reduce(
-          (acc, { path = '', message }) => set(acc, path, message),
-          cleanErrors
-        )
-
-        const liveValidation: LiveValidation = inner.reduce(
-          (acc, { path = '' }) => ({ ...acc, [path]: true }),
-          newWriter.liveValidation
-        )
-
-        const neww = { ...newWriter, errors, liveValidation }
-
-        executeCb(errorCallback)
-
-        return neww
-      })
-    },
-    [executeCb]
-  )
-
-  const validate: Validate<Values> = useCallback(
-    (path, { successCallback, errorCallback, options } = {}) => {
-      setWriter((w) => {
-        // Teardown errors
-        const cleanErrors = set(cloneDeep(w.errors), path, undefined)
-
-        // VALIDATE
-        const inner = validateSyncAll(
-          [path],
-          schemaRef.current,
-          w.form,
-          options
-        )
-
-        if (isEmpty(inner)) {
-          const neww = { ...w, errors: cleanErrors }
-
-          executeCb(successCallback)
-
-          return neww
-        }
-
-        const errors = inner.reduce(
-          (acc, { path: errorPath = '', message }) =>
-            set(acc, errorPath, message),
-          cleanErrors
-        )
-
-        const liveValidation: LiveValidation = inner.reduce(
-          (acc, { path: errorPath = '' }) => ({ ...acc, [errorPath]: true }),
-          w.liveValidation
-        )
-
-        const neww = { ...w, errors, liveValidation }
-
-        executeCb(errorCallback)
-
-        return neww
-      })
-    },
-    [executeCb]
-  )
-
-  const validateAll: ValidateAll<Values> = useCallback(
-    (paths, { successCallback, errorCallback, options } = {}) => {
-      setWriter((w) => {
-        // Teardown errors
-        const cleanErrors = paths.reduce(
-          (acc, path) => set(acc, path, undefined),
-          cloneDeep(w.errors)
-        )
-
-        // VALIDATE ALL
-        const inner = validateSyncAll(
-          paths,
-          schemaRef.current,
-          w.form,
-          options
-        )
-
-        if (isEmpty(inner)) {
-          const neww = { ...w, errors: cleanErrors }
-
-          executeCb(successCallback)
-
-          return neww
-        }
-
-        const errors = inner.reduce(
-          (acc, { path = '', message }) => set(acc, path, message),
-          cleanErrors
-        )
-
-        const liveValidation: LiveValidation = inner.reduce(
-          (acc, { path = '' }) => ({ ...acc, [path]: true }),
-          w.liveValidation
-        )
-
-        const neww = { ...w, errors, liveValidation }
-
-        executeCb(errorCallback)
-
-        return neww
-      })
-    },
-    [executeCb]
-  )
-
-  const check: Check<Partial<Values>> = useCallback(
-    (json, { successCallback, errorCallback, options } = {}) => {
-      try {
-        schema.validateSync(json, { abortEarly: false, ...options })
-        successCallback?.(json, writer, setError)
-
-        return undefined
-      } catch (e) {
-        if (isValidationError(e)) {
-          const { inner } = e
-
-          errorCallback?.(json, inner, writer, setError)
-
-          return inner
-        }
-
-        return undefined
+        return newWriter
       }
-    },
-    [schema, setError, writer]
-  )
 
-  const privateValidateForm: PrivateValidateForm<Partial<Values>> = useCallback(
-    (successCallback, errorCallback, { isDirty: _, options } = {}) => {
-      setWriter((w) => {
-        try {
-          // abortEarly: false as default is to be retrocompatible
-          schemaRef.current.validateSync(w.form, {
-            abortEarly: false,
-            ...options
-          })
+      // Teardown errors
+      const cleanErrors = paths.reduce(
+        (acc, key) => set(acc, key, undefined),
+        cloneDeep(newWriter.errors)
+      )
 
-          executeCb(successCallback)
+      // VALIDATE
+      const inner = validateSyncAll(paths, schemaRef.current, newWriter.form, options)
 
-          return { ...w, errors: {} }
-        } catch (e) {
-          if (!isValidationError(e)) {
-            // Checking if error is not formbit-related (e.g. a bug inside the successCallback)
-            console.error(e)
-            return w
-          }
+      if (isEmpty(inner)) {
+        const neww = { ...newWriter, errors: cleanErrors }
 
-          const { inner } = e
+        executeCb(successCallback)
 
-          const errors = inner.reduce(
-            (acc, { message, path = '' }) => set(acc, path, message),
-            {}
-          )
+        return neww
+      }
 
-          const liveValidation: LiveValidation = inner.reduce(
-            (acc, { path = '' }) => ({ ...acc, [path]: true }),
-            w.liveValidation
-          )
+      const errors = inner.reduce(
+        (acc, { path: innerPath, message }) => innerPath ? set(acc, innerPath, message) : acc,
+        cleanErrors
+      )
 
-          const newWriter = { ...w, errors, liveValidation }
+      const liveValidation: LiveValidation = inner.reduce(
+        (acc, { path: innerPath }) => innerPath ? ({ ...acc, [innerPath]: true }) : acc,
+        newWriter.liveValidation
+      )
 
-          executeCb(errorCallback)
+      const neww = { ...newWriter, errors, liveValidation }
 
-          return newWriter
+      executeCb(errorCallback)
+
+      return neww
+    })
+  }, [executeCb])
+
+  const write: Write<Values> = useCallback((path, value, options) =>
+    writeOrRemove(path, value, options, ACTIONS.write), [writeOrRemove])
+
+  const remove: Remove<Values> = useCallback((path, options) =>
+    writeOrRemove(path, undefined, options, ACTIONS.remove), [writeOrRemove])
+
+  const writeAll: WriteAll<Values> = useCallback((
+    arr,
+    {
+      noLiveValidation = false,
+      pathsToValidate = [],
+      successCallback,
+      errorCallback,
+      options = {}
+    } = {}
+  ) => {
+    setWriter((w) => {
+      const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
+      const paths = pathsToValidate.concat(liveValidationPaths)
+
+      const form = arr.reduce(
+        (acc, [key, val]) => set(acc, key, val),
+        cloneDeep(w.form)
+      )
+
+      const newWriter = { ...w, form, isDirty: true }
+
+      if (paths.length === 0) {
+        executeCb(successCallback)
+
+        return newWriter
+      }
+
+      // Teardown errors
+      const cleanErrors = paths.reduce(
+        (acc, key) => set(acc, key, undefined),
+        cloneDeep(newWriter.errors)
+      )
+
+      // VALIDATE ALL
+      const inner = validateSyncAll(paths, schemaRef.current, newWriter.form, options)
+
+      if (isEmpty(inner)) {
+        const neww = { ...newWriter, errors: cleanErrors }
+
+        executeCb(successCallback)
+
+        return neww
+      }
+
+      const errors = inner.reduce(
+        (acc, { path = '', message }) => set(acc, path, message),
+        cleanErrors
+      )
+
+      const liveValidation: LiveValidation = inner.reduce(
+        (acc, { path = '' }) => ({ ...acc, [path]: true }),
+        newWriter.liveValidation
+      )
+
+      const neww = { ...newWriter, errors, liveValidation }
+
+      executeCb(errorCallback)
+
+      return neww
+    })
+  }, [executeCb])
+
+  const validate: Validate<Values> = useCallback((
+    path,
+    {
+      successCallback,
+      errorCallback,
+      options
+    } = {}
+  ) => {
+    setWriter((w) => {
+      // Teardown errors
+      const cleanErrors = set(cloneDeep(w.errors), path, undefined)
+
+      // VALIDATE
+      const inner = validateSyncAll([path], schemaRef.current, w.form, options)
+
+      if (isEmpty(inner)) {
+        const neww = { ...w, errors: cleanErrors }
+
+        executeCb(successCallback)
+
+        return neww
+      }
+
+      const errors = inner.reduce(
+        (acc, { path: errorPath = '', message }) => set(acc, errorPath, message),
+        cleanErrors
+      )
+
+      const liveValidation: LiveValidation = inner.reduce(
+        (acc, { path: errorPath = '' }) => ({ ...acc, [errorPath]: true }),
+        w.liveValidation
+      )
+
+      const neww = { ...w, errors, liveValidation }
+
+      executeCb(errorCallback)
+
+      return neww
+    })
+  }, [executeCb])
+
+  const validateAll: ValidateAll<Values> = useCallback((
+    paths,
+    { successCallback, errorCallback, options } = {}
+  ) => {
+    setWriter((w) => {
+      // Teardown errors
+      const cleanErrors = paths.reduce(
+        (acc, path) => set(acc, path, undefined),
+        cloneDeep(w.errors)
+      )
+
+      // VALIDATE ALL
+      const inner = validateSyncAll(paths, schemaRef.current, w.form, options)
+
+      if (isEmpty(inner)) {
+        const neww = { ...w, errors: cleanErrors }
+
+        executeCb(successCallback)
+
+        return neww
+      }
+
+      const errors = inner.reduce(
+        (acc, { path = '', message }) => set(acc, path, message),
+        cleanErrors
+      )
+
+      const liveValidation: LiveValidation = inner.reduce(
+        (acc, { path = '' }) => ({ ...acc, [path]: true }),
+        w.liveValidation
+      )
+
+      const neww = { ...w, errors, liveValidation }
+
+      executeCb(errorCallback)
+
+      return neww
+    })
+  }, [executeCb])
+
+  const check: Check<Partial<Values>> = useCallback((
+    json,
+    {
+      successCallback,
+      errorCallback,
+      options
+    } = {}
+  ) => {
+    try {
+      schema.validateSync(json, { abortEarly: false, ...options })
+      successCallback?.(json, writer, setError)
+
+      return undefined
+    } catch (e) {
+      if (isValidationError(e)) {
+        const { inner } = e
+
+        errorCallback?.(json, inner, writer, setError)
+
+        return inner
+      }
+
+      return undefined
+    }
+  }, [schema, setError, writer])
+
+  const privateValidateForm: PrivateValidateForm<Partial<Values>> = useCallback((
+    successCallback,
+    errorCallback,
+    { isDirty: _, options } = {}
+  ) => {
+    setWriter((w) => {
+      try {
+        // abortEarly: false as default is to be retrocompatible
+        schemaRef.current.validateSync(w.form, { abortEarly: false, ...options })
+
+        executeCb(successCallback)
+
+        return { ...w, errors: {} }
+      } catch (e) {
+        if (!isValidationError(e)) {
+          // Checking if error is not formbit-related (e.g. a bug inside the successCallback)
+          console.error(e)
+          return w
         }
-      })
-    },
-    [executeCb]
-  )
 
-  const validateForm: ValidateForm<Partial<Values>> = useCallback(
-    (successCallback, errorCallback, options = {}) =>
-      privateValidateForm(successCallback, errorCallback, { options }),
-    [privateValidateForm]
-  )
+        const { inner } = e
 
-  const submitForm: SubmitForm<Values> = useCallback(
-    (successCallback, errorCallback, options = {}) => {
+        const errors = inner.reduce(
+          (acc, { message, path = '' }) => set(acc, path, message),
+          {}
+        )
+
+        const liveValidation: LiveValidation = inner.reduce(
+          (acc, { path = '' }) => ({ ...acc, [path]: true }),
+          w.liveValidation
+        )
+
+        const newWriter = { ...w, errors, liveValidation }
+
+        executeCb(errorCallback)
+
+        return newWriter
+      }
+    })
+  }, [executeCb])
+
+  const validateForm: ValidateForm<Partial<Values>> = useCallback((successCallback, errorCallback, options = {}) =>
+    privateValidateForm(
+      successCallback,
+      errorCallback,
+      { options }
+    ), [privateValidateForm])
+
+  const submitForm: SubmitForm<Values> =
+    useCallback((successCallback, errorCallback, options = {}) => {
       const fn = () => setWriter((w) => ({ ...w, isDirty: false }))
 
-      const successCallbackAndClearIsDirty: SuccessCallback<Partial<Values>> = (
-        a,
-        b
-      ) => {
+      const successCallbackAndClearIsDirty: SuccessCallback<Partial<Values>> = (a, b) => {
         // Success callback is called only if the form is valid so we can safely cast a as Writer<Values>
         const writer = a as Writer<Values>
 
@@ -445,9 +404,7 @@ export default <Values extends InitialValues>({
         errorCallback,
         { options }
       )
-    },
-    [privateValidateForm]
-  )
+    }, [privateValidateForm])
 
   const resetForm = useCallback(() => {
     setWriter((w) => ({
@@ -469,10 +426,7 @@ export default <Values extends InitialValues>({
     return objLeaves(e).some((leaf) => get(e, leaf))
   }, [writer.errors])
 
-  const error: ErrorFn = useCallback(
-    (path: string) => get(writer.errors, path, undefined),
-    [writer.errors]
-  )
+  const error: ErrorFn = useCallback((path: string) => get(writer.errors, path, undefined), [writer.errors])
 
   const liveValidation: LiveValidationFn = useCallback(
     (path: string) => get(writer.liveValidation, path, undefined),

--- a/src/use-formbit.ts
+++ b/src/use-formbit.ts
@@ -1,7 +1,5 @@
 import objLeaves from './helpers/obj-leaves'
-import {
-  useCallback, useRef, useState
-} from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { ACTIONS } from './helpers/constants'
 import {
   Check,
@@ -32,9 +30,9 @@ import useExecuteCallbacks from './use-execute-callbacks'
 import { cloneDeep, get, isEmpty, omit, set } from 'lodash'
 
 type UseFormbitParams<Values extends InitialValues> = {
-  initialValues?: Partial<Values>,
-  yup: ValidationSchema<Values>
-}
+  initialValues?: Partial<Values>;
+  yup: ValidationSchema<Values>;
+};
 
 export default <Values extends InitialValues>({
   initialValues = {},
@@ -51,17 +49,39 @@ export default <Values extends InitialValues>({
   })
 
   const initialize = useCallback((values: Partial<Values>) => {
-    setWriter((w) => ({
-      ...w,
-      initialValues: values,
-      form: values,
-      errors: {},
-      liveValidation: {},
-      isDirty: false
-    }))
+    const { __metadata } = values
+
+    if (__metadata) {
+      setWriter((w) => ({
+        ...w,
+        initialValues: values,
+        form: values,
+        errors: {},
+        liveValidation: {},
+        isDirty: false
+      }))
+
+      return
+    }
+
+    setWriter((w) => {
+      const { form: { __metadata } } = w
+      const newValues = { ...values, __metadata }
+
+      return {
+        ...w,
+        initialValues: newValues,
+        form: newValues,
+        errors: {},
+        liveValidation: {},
+        isDirty: false
+      }
+    })
   }, [])
 
-  const setSchema = useCallback((newSchema: ValidationSchema<Values>) => { schemaRef.current = newSchema }, [])
+  const setSchema = useCallback((newSchema: ValidationSchema<Values>) => {
+    schemaRef.current = newSchema
+  }, [])
 
   const setError: SetError = useCallback((path, value) => {
     setWriter((w) => {
@@ -73,275 +93,248 @@ export default <Values extends InitialValues>({
 
   const executeCb = useExecuteCallbacks<Partial<Values>>(writer, setError)
 
-  const writeOrRemove: WriteOrRemove<Values> = useCallback((
-    path,
-    value,
-    {
-      noLiveValidation = false,
-      pathsToValidate = [],
-      successCallback,
-      errorCallback,
-      options = {}
-    } = {},
-    action
-  ) => {
-    setWriter((w) => {
-      const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
-      const paths = pathsToValidate.concat(liveValidationPaths)
+  const writeOrRemove: WriteOrRemove<Values> = useCallback(
+    (
+      path,
+      value,
+      {
+        noLiveValidation = false,
+        pathsToValidate = [],
+        successCallback,
+        errorCallback,
+        options = {}
+      } = {},
+      action
+    ) => {
+      setWriter((w) => {
+        const liveValidationPaths = noLiveValidation
+          ? []
+          : Object.keys(w.liveValidation)
+        const paths = pathsToValidate.concat(liveValidationPaths)
 
-      const form = (function execute() {
-        switch (action) {
-          case ACTIONS.write: return set(cloneDeep(w.form), path, value)
+        const form = (function execute() {
+          switch (action) {
+            case ACTIONS.write:
+              return set(cloneDeep(w.form), path, value)
 
-          case ACTIONS.remove: return omit<Partial<Values>>(cloneDeep(w.form), path)
+            case ACTIONS.remove:
+              return omit<Partial<Values>>(cloneDeep(w.form), path)
 
-          default: return cloneDeep(w.form)
-        }
-      }())
+            default:
+              return cloneDeep(w.form)
+          }
+        })()
 
-      const newWriter: Writer<Partial<Values>> = { ...w, form, isDirty: true }
-
-      if (paths.length === 0) {
-        executeCb(successCallback)
-
-        return newWriter
-      }
-
-      // Teardown errors
-      const cleanErrors = paths.reduce(
-        (acc, key) => set(acc, key, undefined),
-        cloneDeep(newWriter.errors)
-      )
-
-      // VALIDATE
-      const inner = validateSyncAll(paths, schemaRef.current, newWriter.form, options)
-
-      if (isEmpty(inner)) {
-        const neww = { ...newWriter, errors: cleanErrors }
-
-        executeCb(successCallback)
-
-        return neww
-      }
-
-      const errors = inner.reduce(
-        (acc, { path: innerPath, message }) => innerPath ? set(acc, innerPath, message) : acc,
-        cleanErrors
-      )
-
-      const liveValidation: LiveValidation = inner.reduce(
-        (acc, { path: innerPath }) => innerPath ? ({ ...acc, [innerPath]: true }) : acc,
-        newWriter.liveValidation
-      )
-
-      const neww = { ...newWriter, errors, liveValidation }
-
-      executeCb(errorCallback)
-
-      return neww
-    })
-  }, [executeCb])
-
-  const write: Write<Values> = useCallback((path, value, options) =>
-    writeOrRemove(path, value, options, ACTIONS.write), [writeOrRemove])
-
-  const remove: Remove<Values> = useCallback((path, options) =>
-    writeOrRemove(path, undefined, options, ACTIONS.remove), [writeOrRemove])
-
-  const writeAll: WriteAll<Values> = useCallback((
-    arr,
-    {
-      noLiveValidation = false,
-      pathsToValidate = [],
-      successCallback,
-      errorCallback,
-      options = {}
-    } = {}
-  ) => {
-    setWriter((w) => {
-      const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
-      const paths = pathsToValidate.concat(liveValidationPaths)
-
-      const form = arr.reduce(
-        (acc, [key, val]) => set(acc, key, val),
-        cloneDeep(w.form)
-      )
-
-      const newWriter = { ...w, form, isDirty: true }
-
-      if (paths.length === 0) {
-        executeCb(successCallback)
-
-        return newWriter
-      }
-
-      // Teardown errors
-      const cleanErrors = paths.reduce(
-        (acc, key) => set(acc, key, undefined),
-        cloneDeep(newWriter.errors)
-      )
-
-      // VALIDATE ALL
-      const inner = validateSyncAll(paths, schemaRef.current, newWriter.form, options)
-
-      if (isEmpty(inner)) {
-        const neww = { ...newWriter, errors: cleanErrors }
-
-        executeCb(successCallback)
-
-        return neww
-      }
-
-      const errors = inner.reduce(
-        (acc, { path = '', message }) => set(acc, path, message),
-        cleanErrors
-      )
-
-      const liveValidation: LiveValidation = inner.reduce(
-        (acc, { path = '' }) => ({ ...acc, [path]: true }),
-        newWriter.liveValidation
-      )
-
-      const neww = { ...newWriter, errors, liveValidation }
-
-      executeCb(errorCallback)
-
-      return neww
-    })
-  }, [executeCb])
-
-  const validate: Validate<Values> = useCallback((
-    path,
-    {
-      successCallback,
-      errorCallback,
-      options
-    } = {}
-  ) => {
-    setWriter((w) => {
-      // Teardown errors
-      const cleanErrors = set(cloneDeep(w.errors), path, undefined)
-
-      // VALIDATE
-      const inner = validateSyncAll([path], schemaRef.current, w.form, options)
-
-      if (isEmpty(inner)) {
-        const neww = { ...w, errors: cleanErrors }
-
-        executeCb(successCallback)
-
-        return neww
-      }
-
-      const errors = inner.reduce(
-        (acc, { path: errorPath = '', message }) => set(acc, errorPath, message),
-        cleanErrors
-      )
-
-      const liveValidation: LiveValidation = inner.reduce(
-        (acc, { path: errorPath = '' }) => ({ ...acc, [errorPath]: true }),
-        w.liveValidation
-      )
-
-      const neww = { ...w, errors, liveValidation }
-
-      executeCb(errorCallback)
-
-      return neww
-    })
-  }, [executeCb])
-
-  const validateAll: ValidateAll<Values> = useCallback((
-    paths,
-    { successCallback, errorCallback, options } = {}
-  ) => {
-    setWriter((w) => {
-      // Teardown errors
-      const cleanErrors = paths.reduce(
-        (acc, path) => set(acc, path, undefined),
-        cloneDeep(w.errors)
-      )
-
-      // VALIDATE ALL
-      const inner = validateSyncAll(paths, schemaRef.current, w.form, options)
-
-      if (isEmpty(inner)) {
-        const neww = { ...w, errors: cleanErrors }
-
-        executeCb(successCallback)
-
-        return neww
-      }
-
-      const errors = inner.reduce(
-        (acc, { path = '', message }) => set(acc, path, message),
-        cleanErrors
-      )
-
-      const liveValidation: LiveValidation = inner.reduce(
-        (acc, { path = '' }) => ({ ...acc, [path]: true }),
-        w.liveValidation
-      )
-
-      const neww = { ...w, errors, liveValidation }
-
-      executeCb(errorCallback)
-
-      return neww
-    })
-  }, [executeCb])
-
-  const check: Check<Partial<Values>> = useCallback((
-    json,
-    {
-      successCallback,
-      errorCallback,
-      options
-    } = {}
-  ) => {
-    try {
-      schema.validateSync(json, { abortEarly: false, ...options })
-      successCallback?.(json, writer, setError)
-
-      return undefined
-    } catch (e) {
-      if (isValidationError(e)) {
-        const { inner } = e
-
-        errorCallback?.(json, inner, writer, setError)
-
-        return inner
-      }
-
-      return undefined
-    }
-  }, [schema, setError, writer])
-
-  const privateValidateForm: PrivateValidateForm<Partial<Values>> = useCallback((
-    successCallback,
-    errorCallback,
-    { isDirty: _, options } = {}
-  ) => {
-    setWriter((w) => {
-      try {
-        // abortEarly: false as default is to be retrocompatible
-        schemaRef.current.validateSync(w.form, { abortEarly: false, ...options })
-
-        executeCb(successCallback)
-
-        return { ...w, errors: {} }
-      } catch (e) {
-        if (!isValidationError(e)) {
-          // Checking if error is not formbit-related (e.g. a bug inside the successCallback)
-          console.error(e)
-          return w
+        const newWriter: Writer<Partial<Values>> = {
+          ...w,
+          form,
+          isDirty: true
         }
 
-        const { inner } = e
+        if (paths.length === 0) {
+          executeCb(successCallback)
+
+          return newWriter
+        }
+
+        // Teardown errors
+        const cleanErrors = paths.reduce(
+          (acc, key) => set(acc, key, undefined),
+          cloneDeep(newWriter.errors)
+        )
+
+        // VALIDATE
+        const inner = validateSyncAll(
+          paths,
+          schemaRef.current,
+          newWriter.form,
+          options
+        )
+
+        if (isEmpty(inner)) {
+          const neww = { ...newWriter, errors: cleanErrors }
+
+          executeCb(successCallback)
+
+          return neww
+        }
 
         const errors = inner.reduce(
-          (acc, { message, path = '' }) => set(acc, path, message),
-          {}
+          (acc, { path: innerPath, message }) =>
+            innerPath ? set(acc, innerPath, message) : acc,
+          cleanErrors
+        )
+
+        const liveValidation: LiveValidation = inner.reduce(
+          (acc, { path: innerPath }) =>
+            innerPath ? { ...acc, [innerPath]: true } : acc,
+          newWriter.liveValidation
+        )
+
+        const neww = { ...newWriter, errors, liveValidation }
+
+        executeCb(errorCallback)
+
+        return neww
+      })
+    },
+    [executeCb]
+  )
+
+  const write: Write<Values> = useCallback(
+    (path, value, options) =>
+      writeOrRemove(path, value, options, ACTIONS.write),
+    [writeOrRemove]
+  )
+
+  const remove: Remove<Values> = useCallback(
+    (path, options) => writeOrRemove(path, undefined, options, ACTIONS.remove),
+    [writeOrRemove]
+  )
+
+  const writeAll: WriteAll<Values> = useCallback(
+    (
+      arr,
+      {
+        noLiveValidation = false,
+        pathsToValidate = [],
+        successCallback,
+        errorCallback,
+        options = {}
+      } = {}
+    ) => {
+      setWriter((w) => {
+        const liveValidationPaths = noLiveValidation
+          ? []
+          : Object.keys(w.liveValidation)
+        const paths = pathsToValidate.concat(liveValidationPaths)
+
+        const form = arr.reduce(
+          (acc, [key, val]) => set(acc, key, val),
+          cloneDeep(w.form)
+        )
+
+        const newWriter = { ...w, form, isDirty: true }
+
+        if (paths.length === 0) {
+          executeCb(successCallback)
+
+          return newWriter
+        }
+
+        // Teardown errors
+        const cleanErrors = paths.reduce(
+          (acc, key) => set(acc, key, undefined),
+          cloneDeep(newWriter.errors)
+        )
+
+        // VALIDATE ALL
+        const inner = validateSyncAll(
+          paths,
+          schemaRef.current,
+          newWriter.form,
+          options
+        )
+
+        if (isEmpty(inner)) {
+          const neww = { ...newWriter, errors: cleanErrors }
+
+          executeCb(successCallback)
+
+          return neww
+        }
+
+        const errors = inner.reduce(
+          (acc, { path = '', message }) => set(acc, path, message),
+          cleanErrors
+        )
+
+        const liveValidation: LiveValidation = inner.reduce(
+          (acc, { path = '' }) => ({ ...acc, [path]: true }),
+          newWriter.liveValidation
+        )
+
+        const neww = { ...newWriter, errors, liveValidation }
+
+        executeCb(errorCallback)
+
+        return neww
+      })
+    },
+    [executeCb]
+  )
+
+  const validate: Validate<Values> = useCallback(
+    (path, { successCallback, errorCallback, options } = {}) => {
+      setWriter((w) => {
+        // Teardown errors
+        const cleanErrors = set(cloneDeep(w.errors), path, undefined)
+
+        // VALIDATE
+        const inner = validateSyncAll(
+          [path],
+          schemaRef.current,
+          w.form,
+          options
+        )
+
+        if (isEmpty(inner)) {
+          const neww = { ...w, errors: cleanErrors }
+
+          executeCb(successCallback)
+
+          return neww
+        }
+
+        const errors = inner.reduce(
+          (acc, { path: errorPath = '', message }) =>
+            set(acc, errorPath, message),
+          cleanErrors
+        )
+
+        const liveValidation: LiveValidation = inner.reduce(
+          (acc, { path: errorPath = '' }) => ({ ...acc, [errorPath]: true }),
+          w.liveValidation
+        )
+
+        const neww = { ...w, errors, liveValidation }
+
+        executeCb(errorCallback)
+
+        return neww
+      })
+    },
+    [executeCb]
+  )
+
+  const validateAll: ValidateAll<Values> = useCallback(
+    (paths, { successCallback, errorCallback, options } = {}) => {
+      setWriter((w) => {
+        // Teardown errors
+        const cleanErrors = paths.reduce(
+          (acc, path) => set(acc, path, undefined),
+          cloneDeep(w.errors)
+        )
+
+        // VALIDATE ALL
+        const inner = validateSyncAll(
+          paths,
+          schemaRef.current,
+          w.form,
+          options
+        )
+
+        if (isEmpty(inner)) {
+          const neww = { ...w, errors: cleanErrors }
+
+          executeCb(successCallback)
+
+          return neww
+        }
+
+        const errors = inner.reduce(
+          (acc, { path = '', message }) => set(acc, path, message),
+          cleanErrors
         )
 
         const liveValidation: LiveValidation = inner.reduce(
@@ -349,27 +342,95 @@ export default <Values extends InitialValues>({
           w.liveValidation
         )
 
-        const newWriter = { ...w, errors, liveValidation }
+        const neww = { ...w, errors, liveValidation }
 
         executeCb(errorCallback)
 
-        return newWriter
+        return neww
+      })
+    },
+    [executeCb]
+  )
+
+  const check: Check<Partial<Values>> = useCallback(
+    (json, { successCallback, errorCallback, options } = {}) => {
+      try {
+        schema.validateSync(json, { abortEarly: false, ...options })
+        successCallback?.(json, writer, setError)
+
+        return undefined
+      } catch (e) {
+        if (isValidationError(e)) {
+          const { inner } = e
+
+          errorCallback?.(json, inner, writer, setError)
+
+          return inner
+        }
+
+        return undefined
       }
-    })
-  }, [executeCb])
+    },
+    [schema, setError, writer]
+  )
 
-  const validateForm: ValidateForm<Partial<Values>> = useCallback((successCallback, errorCallback, options = {}) =>
-    privateValidateForm(
-      successCallback,
-      errorCallback,
-      { options }
-    ), [privateValidateForm])
+  const privateValidateForm: PrivateValidateForm<Partial<Values>> = useCallback(
+    (successCallback, errorCallback, { isDirty: _, options } = {}) => {
+      setWriter((w) => {
+        try {
+          // abortEarly: false as default is to be retrocompatible
+          schemaRef.current.validateSync(w.form, {
+            abortEarly: false,
+            ...options
+          })
 
-  const submitForm: SubmitForm<Values> =
-    useCallback((successCallback, errorCallback, options = {}) => {
+          executeCb(successCallback)
+
+          return { ...w, errors: {} }
+        } catch (e) {
+          if (!isValidationError(e)) {
+            // Checking if error is not formbit-related (e.g. a bug inside the successCallback)
+            console.error(e)
+            return w
+          }
+
+          const { inner } = e
+
+          const errors = inner.reduce(
+            (acc, { message, path = '' }) => set(acc, path, message),
+            {}
+          )
+
+          const liveValidation: LiveValidation = inner.reduce(
+            (acc, { path = '' }) => ({ ...acc, [path]: true }),
+            w.liveValidation
+          )
+
+          const newWriter = { ...w, errors, liveValidation }
+
+          executeCb(errorCallback)
+
+          return newWriter
+        }
+      })
+    },
+    [executeCb]
+  )
+
+  const validateForm: ValidateForm<Partial<Values>> = useCallback(
+    (successCallback, errorCallback, options = {}) =>
+      privateValidateForm(successCallback, errorCallback, { options }),
+    [privateValidateForm]
+  )
+
+  const submitForm: SubmitForm<Values> = useCallback(
+    (successCallback, errorCallback, options = {}) => {
       const fn = () => setWriter((w) => ({ ...w, isDirty: false }))
 
-      const successCallbackAndClearIsDirty: SuccessCallback<Partial<Values>> = (a, b) => {
+      const successCallbackAndClearIsDirty: SuccessCallback<Partial<Values>> = (
+        a,
+        b
+      ) => {
         // Success callback is called only if the form is valid so we can safely cast a as Writer<Values>
         const writer = a as Writer<Values>
 
@@ -384,7 +445,9 @@ export default <Values extends InitialValues>({
         errorCallback,
         { options }
       )
-    }, [privateValidateForm])
+    },
+    [privateValidateForm]
+  )
 
   const resetForm = useCallback(() => {
     setWriter((w) => ({
@@ -406,7 +469,10 @@ export default <Values extends InitialValues>({
     return objLeaves(e).some((leaf) => get(e, leaf))
   }, [writer.errors])
 
-  const error: ErrorFn = useCallback((path: string) => get(writer.errors, path, undefined), [writer.errors])
+  const error: ErrorFn = useCallback(
+    (path: string) => get(writer.errors, path, undefined),
+    [writer.errors]
+  )
 
   const liveValidation: LiveValidationFn = useCallback(
     (path: string) => get(writer.liveValidation, path, undefined),


### PR DESCRIPTION
When the programmer call the initialize method the __metadata field should't be touched. They must be overwritten if the programmer specify new values for them in the initialize method invocation.