### PR TITLE
fix: make successCallback and errorCallback management idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.1.0](https://github.com/radicalbit/formbit/compare/v1.0.0...v1.1.0) (2024-06-20)
+
+
+### Features
+
+* install design-system v1.0.0 ([#2](https://github.com/radicalbit/formbit/issues/2)) ([a3af098](https://github.com/radicalbit/formbit/commit/a3af098b63b2fee88f742512d0fa5be67891a4d6))
+
 ## 1.0.0 (2024-06-18)
 
 ### Features

--- a/example/src/forms/multiple-steps/step-one.tsx
+++ b/example/src/forms/multiple-steps/step-one.tsx
@@ -25,7 +25,7 @@ export function StepOne() {
 function Name() {
     const { form, error, write } = useMultipleStepsForm();
 
-    const [handleOnNext] = useHandleNextStep()
+    const [handleOnNext] = useHandleNextStep(['name', 'surname'])
 
     const handleOnChangeName = (e: ChangeEvent<HTMLInputElement>) => write('name', e.target.value);
 
@@ -48,7 +48,7 @@ function Name() {
 function Surname() {
     const { form, error, write } = useMultipleStepsForm();
 
-    const [handleOnNext] = useHandleNextStep()
+    const [handleOnNext] = useHandleNextStep(['name', 'surname'])
 
     const handleOnChangeSurname = (e: ChangeEvent<HTMLInputElement>) => write('surname', e.target.value);
 

--- a/example/src/forms/multiple-steps/step-two.tsx
+++ b/example/src/forms/multiple-steps/step-two.tsx
@@ -22,7 +22,8 @@ export function StepTwo() {
 function Age() {
     const { form, error, write } = useMultipleStepsForm()
 
-    const [handleOnNext] = useHandleNextStep()
+    
+    const [handleOnNext] = useHandleNextStep(['age'])
 
     const handleOnChangeInputNumber = (value?: number | null) => write('age', value);
 
@@ -47,7 +48,7 @@ function Age() {
 function Actions() {
     const { form: { __metadata } } = useMultipleStepsForm();
 
-    const [handleOnNext, isStepInvalid] = useHandleNextStep();
+    const [handleOnNext, isStepInvalid] = useHandleNextStep(['age'])
 
     const prevStep = __metadata?.prevStep;
 

--- a/example/src/forms/multiple-steps/use-handle-next-step.ts
+++ b/example/src/forms/multiple-steps/use-handle-next-step.ts
@@ -8,14 +8,14 @@ type Context = {
     }
  }
 
-export const useHandleNextStep = (fields?: string[]) => {
+export const useHandleNextStep = (fields: string[]) => {
     const { form: { __metadata }, validateAll, error } = useFormbitContext<Context>();
 
     const nextStep = __metadata?.nextStep
 
     const handleOnNext = useCallback(
-        () => validateAll(['name', 'surname'], { successCallback: nextStep }),
-        [nextStep, validateAll]
+        () => validateAll(fields, { successCallback: nextStep }),
+        [fields, nextStep, validateAll]
     );
 
     const isStepInvalid = fields?.some(field => error(field))

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/lodash": "^4.0.0",
     "@types/react": "^18.2.71",
     "@types/react-dom": "^18.2.22",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "babel-eslint": "^10.0.3",
@@ -77,6 +78,7 @@
     "typescript-eslint": "^7.4.0"
   },
   "dependencies": {
+    "uuid": "^10.0.0",
     "yup": "^1.4.0"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radicalbit/formbit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Lightweight state form library",
   "author": "https://github.com/radicalbit",
   "license": "MIT",

--- a/src/use-formbit.ts
+++ b/src/use-formbit.ts
@@ -30,6 +30,7 @@ import { isValidationError } from './types/helpers'
 import { validateSyncAll } from './validate-sync-all'
 import useExecuteCallbacks from './use-execute-callbacks'
 import { cloneDeep, get, isEmpty, omit, set } from 'lodash'
+import { v4 as uuidv4 } from 'uuid'
 
 type UseFormbitParams<Values extends InitialValues> = {
   initialValues?: Partial<Values>,
@@ -85,6 +86,8 @@ export default <Values extends InitialValues>({
     } = {},
     action
   ) => {
+    const newUUID = uuidv4()
+
     setWriter((w) => {
       const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
       const paths = pathsToValidate.concat(liveValidationPaths)
@@ -102,7 +105,7 @@ export default <Values extends InitialValues>({
       const newWriter: Writer<Partial<Values>> = { ...w, form, isDirty: true }
 
       if (paths.length === 0) {
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return newWriter
       }
@@ -119,7 +122,7 @@ export default <Values extends InitialValues>({
       if (isEmpty(inner)) {
         const neww = { ...newWriter, errors: cleanErrors }
 
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return neww
       }
@@ -136,7 +139,7 @@ export default <Values extends InitialValues>({
 
       const neww = { ...newWriter, errors, liveValidation }
 
-      executeCb(errorCallback)
+      executeCb(newUUID, errorCallback)
 
       return neww
     })
@@ -158,6 +161,8 @@ export default <Values extends InitialValues>({
       options = {}
     } = {}
   ) => {
+    const newUUID = uuidv4()
+
     setWriter((w) => {
       const liveValidationPaths = noLiveValidation ? [] : Object.keys(w.liveValidation)
       const paths = pathsToValidate.concat(liveValidationPaths)
@@ -170,7 +175,7 @@ export default <Values extends InitialValues>({
       const newWriter = { ...w, form, isDirty: true }
 
       if (paths.length === 0) {
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return newWriter
       }
@@ -187,7 +192,7 @@ export default <Values extends InitialValues>({
       if (isEmpty(inner)) {
         const neww = { ...newWriter, errors: cleanErrors }
 
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return neww
       }
@@ -204,7 +209,7 @@ export default <Values extends InitialValues>({
 
       const neww = { ...newWriter, errors, liveValidation }
 
-      executeCb(errorCallback)
+      executeCb(newUUID, errorCallback)
 
       return neww
     })
@@ -218,6 +223,8 @@ export default <Values extends InitialValues>({
       options
     } = {}
   ) => {
+    const newUUID = uuidv4()
+
     setWriter((w) => {
       // Teardown errors
       const cleanErrors = set(cloneDeep(w.errors), path, undefined)
@@ -228,7 +235,7 @@ export default <Values extends InitialValues>({
       if (isEmpty(inner)) {
         const neww = { ...w, errors: cleanErrors }
 
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return neww
       }
@@ -245,7 +252,7 @@ export default <Values extends InitialValues>({
 
       const neww = { ...w, errors, liveValidation }
 
-      executeCb(errorCallback)
+      executeCb(newUUID, errorCallback)
 
       return neww
     })
@@ -255,6 +262,8 @@ export default <Values extends InitialValues>({
     paths,
     { successCallback, errorCallback, options } = {}
   ) => {
+    const newUUID = uuidv4()
+
     setWriter((w) => {
       // Teardown errors
       const cleanErrors = paths.reduce(
@@ -268,7 +277,7 @@ export default <Values extends InitialValues>({
       if (isEmpty(inner)) {
         const neww = { ...w, errors: cleanErrors }
 
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return neww
       }
@@ -285,7 +294,7 @@ export default <Values extends InitialValues>({
 
       const neww = { ...w, errors, liveValidation }
 
-      executeCb(errorCallback)
+      executeCb(newUUID, errorCallback)
 
       return neww
     })
@@ -322,12 +331,14 @@ export default <Values extends InitialValues>({
     errorCallback,
     { isDirty: _, options } = {}
   ) => {
+    const newUUID = uuidv4()
+
     setWriter((w) => {
       try {
         // abortEarly: false as default is to be retrocompatible
         schemaRef.current.validateSync(w.form, { abortEarly: false, ...options })
 
-        executeCb(successCallback)
+        executeCb(newUUID, successCallback)
 
         return { ...w, errors: {} }
       } catch (e) {
@@ -351,7 +362,7 @@ export default <Values extends InitialValues>({
 
         const newWriter = { ...w, errors, liveValidation }
 
-        executeCb(errorCallback)
+        executeCb(newUUID, errorCallback)
 
         return newWriter
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3396,6 +3396,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.10.tgz#04ffa7f406ab628f7f7e97ca23e290cd8ab15efc"
   integrity sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==
 
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
+
 "@types/ws@^8.5.5":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
@@ -13527,6 +13532,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
+
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
We were handling the callbacks using an array.push method. That approach weren't idempotent and the React Strict mode showed that to us. We changed from an array.push approach to a dictionary approach in order to avoid that the Strict mode will lead to unwanted execution of a successCallback or an errorCallback